### PR TITLE
update the copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,13 +282,12 @@
                     <a id="github" href="https://github.com/ritinlug" target="_blank"><i class="fa fa-github-square fa-3x sr-contact"></i></a>
                </div>
             </div>
-
-
-</section>
+        </div>
+    </section>
 
     <div id="copyright-footer" style="padding: 30px 0;">
 	<div class="text-center">
-	    Copyright © <span style="color: #F05F40">ritinlug</span> 2017
+	    Copyright © <span style="color: #F05F40">ritinlug</span> 2017-2018
 	</div>
     </div>
 


### PR DESCRIPTION
Fix #13 
Following are the changes in the `index.html` file:

- Updated the copyright year from `2017` to `2017-2018`

- Added `</div>` tag to close `<div class="container">` under `contact` section id.
